### PR TITLE
nvergara

### DIFF
--- a/src/app/interfaces/interfaces.ts
+++ b/src/app/interfaces/interfaces.ts
@@ -107,3 +107,7 @@ export interface Emisor {
   comunidad ?: Comunidad;
   estado?: number;
 }
+
+export interface RespuestaComunidad {
+  puedeEmitir: number;
+}

--- a/src/app/pages/crear-cert/crear-cert.page.html
+++ b/src/app/pages/crear-cert/crear-cert.page.html
@@ -4,15 +4,6 @@
       <ion-back-button defaultHref="/main/tabs/tab1" color="light"></ion-back-button>
     </ion-buttons>
     <ion-title  class="vecired" color="light">VeciRed</ion-title>
-    <ion-buttons  
-                  (click)="openModal()"
-                  slot="end"
-                  color="light">
-                  <ion-icon slot="icon-only" name="help-circle-outline" color="light"></ion-icon>
-
-      
-
-    </ion-buttons>
   </ion-toolbar>
 </ion-header>
 

--- a/src/app/pages/mis-certificados/mis-certificados.page.ts
+++ b/src/app/pages/mis-certificados/mis-certificados.page.ts
@@ -5,7 +5,9 @@ import { Router, NavigationExtras } from '@angular/router';
 import { UsuarioService } from 'src/app/servicios/usuario.service';
 import { AlertController } from '@ionic/angular';
 import { EmisorService } from 'src/app/servicios/emisor.service';
-
+import { ComunidadService } from 'src/app/servicios/comunidad.service';
+import { RespuestaComunidad } from 'src/app/interfaces/interfaces';
+import { AlertasService } from 'src/app/servicios/alertas.service';
 
 @Component({
   selector: 'app-mis-certificados',
@@ -25,29 +27,47 @@ export class MisCertificadosPage implements OnInit {
   Roltype = [];
   usuario: Usuario = {};
   mostrarInputMensaje = false;
-
-
+  aux;
+  noVerificado = false;
+  
   constructor(private certificadoService: CertificadoService,
               private ruta: Router,
               private usuarioService: UsuarioService,
               private alertController: AlertController,
-              private emisorService: EmisorService
+              private emisorService: EmisorService,
+              private comunidadService: ComunidadService,
+              private alertaService: AlertasService
               ) { }
 
   ngOnInit() {
     this.loadCertificados(); // Cargamos los certificados al entrar en la página.
   }
 
+  
   ionViewDidEnter() {
     this.loadCertificados(); // Llamamos a la función al entrar en la página.
     //this.obtenerRol();
     this.obtenerRolUsuario();
+    this.puedeEmitir();
   }
 
   obtenerRolUsuario(){
     this.usuario = this.usuarioService.obtenerRolUsuario();
     this.Roltype[0] = this.usuario.rol;
     //console.log(this.usuario.rol);
+    
+  }
+
+  puedeEmitir() {
+    this.comunidadService.obtenerComunidad().subscribe(
+      (datos: RespuestaComunidad) => {
+        this.aux = datos.puedeEmitir;
+      },
+      (error) => {
+        // Manejo de errores :3
+        console.error('Este es el error: ', error);
+      }
+    );
   }
 
   loadCertificados() {
@@ -72,23 +92,23 @@ export class MisCertificadosPage implements OnInit {
     //console.log(id);
     //this.ruta.navigateByUrl('/main/tabs/crear-cert');
 
-    if (this.Roltype[0] === 2) {
-      // Si el rol es 2 muestra alerta
-      const alert = await this.alertController.create({
-        message: 'Solo personas de la directiva pueden crear certificados.',
-        buttons: ['OK']
-      });
-  
-      await alert.present();
-    } else {
+    if(this.Roltype[0] === 2 && this.aux === 1){
+      this.alertaService.alerta('Solo personas de la directiva pueden crear certificados.');
+
+    }if(this.Roltype[0] === 1 && this.aux === 0){
+      this.alertaService.alerta('Su comunidad no esta verificada para emitir certificados.');
+    }if(this.Roltype[0] === 2 && this.aux ===0){
+      this.alertaService.alerta('Esta comunidad no se encuentra verificada.');
+    
+    }if(this.Roltype[0] === 1 && this.aux ===1) {
       this.ruta.navigateByUrl('main/tabs/crear-cert');
     }
-
+  
+    
   }
 
   async editarCerticado(certificado) {
     if (this.Roltype[0] === 2) {
-      // Si el rol es 2 muestra alerta
       const alert = await this.alertController.create({
         message: 'Solo personas de la directiva tienen permiso para editar el certificado.',
         buttons: ['OK']

--- a/src/app/servicios/comunidad.service.ts
+++ b/src/app/servicios/comunidad.service.ts
@@ -15,7 +15,7 @@ const url = environment.url;
 export class ComunidadService {
 
   nuevaComunidad = new EventEmitter<Comunidad>();
-
+  comunidad: Comunidad ={};
   //Objeto = new EventEmitter<Comunidad>();
   Objeto = new ReplaySubject<{}>();
 
@@ -97,4 +97,15 @@ export class ComunidadService {
     
 
   }
+
+  obtenerComunidad(){
+    const headers = new HttpHeaders({
+      'UToken': this.usuarioService.userToken
+    });
+
+    return this.http.get(`${url}/comunidad/puedeemitir`,{headers});
+
+
+  }
+
 }


### PR DESCRIPTION
- se agrega mis-certificados a /pages/ y se pueden ver los certificados de la comunidad elegida
- se hace que mis certificados muestre posts, y si esta vacio muestre un aviso de comunidad que no puede generar certificados
- cambios en la pestaña de certificados, boton para crear, editar y emitir
- se cambia el formato que se renderizan los certificados y boton actualizar funciona
- ahora hay una alerta cuando se trata de actualizar certificados sin tener el rol necesario
- se crea emisor y recibe informacion desde backend, falta renderizarla
- funcionalidad de notificacion de landing page vacia funcionando
- gestionar certificados tiene infinite scroll, mensaje cuando se llega al final del infinite scroll compatible con landing page de comunidad sin certificados
- botones de moderacion certificados{aprobar y rechazar} funcionando!
- ver estado de mis certificados funcionando, se agrega boton de generar certificado si emitir esta en estado aprobado
- cambios mis estados de certificado, visuales mas que nada
- logo bold, mis certificados pull to refresh, no mis certificados aviso e infinite scroll
- ahora funciona el primer post(certificados)
- ESTA VIVOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO (funciona el emisor de certificados)
- cambios esteticos, de ruta para el emitir certificado y validaciones emitir certificado
- see you space cowboy
